### PR TITLE
Capture real claim character spans for source highlighting

### DIFF
--- a/hybrid_citation_scraper/claim_extractor.py
+++ b/hybrid_citation_scraper/claim_extractor.py
@@ -9,6 +9,7 @@ Architecture:
 """
 
 import json
+import re
 import sys
 from typing import List, Dict, Tuple, Optional
 from pathlib import Path
@@ -31,7 +32,45 @@ from .utils import (
     semantic_chunk_text
 )
 from .llm_client import LLMClient
-from models import ClaimObject, CitationDetails
+from models import ClaimObject, CitationDetails, LocationInText
+
+
+def _locate_claim_span(
+    full_text: str, claim_text: str, hint: int = 0
+) -> Tuple[Optional[int], Optional[int]]:
+    """Return the (start, end) character offsets of ``claim_text`` in ``full_text``.
+
+    The LLM returns claim text but no offsets, and it often normalizes
+    whitespace (collapsing newlines and runs of spaces). We therefore try an
+    exact substring match first, then fall back to a whitespace-tolerant regex
+    that matches the same non-whitespace tokens across any run of whitespace.
+
+    ``hint`` (the claim's chunk ``start_pos``) is used as a search start so that
+    a sentence repeated elsewhere in the document resolves to the occurrence in
+    the claim's own chunk. Returns ``(None, None)`` when the claim cannot be
+    located (e.g. the LLM paraphrased it), so callers can tell "unknown" apart
+    from "offset 0".
+    """
+    if not claim_text:
+        return None, None
+
+    # Exact match: prefer an occurrence at/after the hint, else search from 0.
+    for start_at in (max(0, hint), 0):
+        idx = full_text.find(claim_text, start_at)
+        if idx != -1:
+            return idx, idx + len(claim_text)
+
+    # Whitespace-tolerant fallback: match the claim's tokens across any gaps.
+    tokens = claim_text.split()
+    if not tokens:
+        return None, None
+    pattern = re.compile(r"\s+".join(re.escape(tok) for tok in tokens))
+    for start_at in (max(0, hint), 0):
+        match = pattern.search(full_text, start_at)
+        if match:
+            return match.start(), match.end()
+
+    return None, None
 
 
 class HybridClaimExtractor:
@@ -119,12 +158,19 @@ class HybridClaimExtractor:
                 paper_abstract=self.paper_abstract
             )
             
-            # Update location information
+            # Record each claim's exact character span in the full document
+            # text so consumers can highlight it in the source. The chunk's
+            # start_pos is only a search hint here — offsets are resolved
+            # against the real text, not the whitespace-normalized chunk.
             for claim in claims:
-                if claim.location_in_text:
-                    claim.location_in_text.start += chunk['start_pos']
-                    claim.location_in_text.end += chunk['start_pos']
-            
+                start, end = _locate_claim_span(
+                    text, claim.text, hint=chunk['start_pos']
+                )
+                if claim.location_in_text is None:
+                    claim.location_in_text = LocationInText(chunk_id=chunk['chunk_id'])
+                claim.location_in_text.start = start
+                claim.location_in_text.end = end
+
             all_claims.extend(claims)
         
         print(f"\n✓ Extracted {len(all_claims)} claims")

--- a/hybrid_citation_scraper/llm_client.py
+++ b/hybrid_citation_scraper/llm_client.py
@@ -193,11 +193,9 @@ class LLMClient:
                     citation_text=claim_data.get("citation_marker"),
                     citation_details=None,  # Will be populated later
                     is_original=claim_data.get("is_original", False),
-                    location_in_text=LocationInText(
-                        start=0,  # Would need more sophisticated tracking
-                        end=0,
-                        chunk_id=chunk_id
-                    )
+                    # start/end are filled in by the extractor, which has the
+                    # full document text to locate the claim against.
+                    location_in_text=LocationInText(chunk_id=chunk_id)
                 )
                 claims.append(claim)
 

--- a/hybrid_citation_scraper/tests/test_claim_extractor.py
+++ b/hybrid_citation_scraper/tests/test_claim_extractor.py
@@ -172,32 +172,98 @@ class TestExtractClaimsFromText:
     
     @patch('hybrid_citation_scraper.claim_extractor.LLMClient')
     @patch('hybrid_citation_scraper.claim_extractor.semantic_chunk_text')
-    def test_extract_claims_updates_location(
+    def test_extract_claims_locates_claim_span(
         self, mock_chunk, mock_llm_client
     ):
-        """Test that claim locations are updated with chunk position"""
+        """start/end are exact character offsets into the full document text."""
+        full_text = "Intro sentence. The sky is blue. Outro sentence."
+        span_start = full_text.index("The sky is blue.")
         mock_chunk.return_value = [
-            {'chunk_id': 0, 'text': 'Chunk', 'start_pos': 100, 'end_pos': 105, 'token_count': 1}
+            {'chunk_id': 0, 'text': 'The sky is blue.',
+             'start_pos': span_start, 'end_pos': span_start + 16, 'token_count': 4}
         ]
-        
+
         claim = ClaimObject(
             claim_id="test",
-            text="Test claim",
+            text="The sky is blue.",
             claim_type="qualitative",
             citation_found=False,
             is_original=True,
-            location_in_text=LocationInText(start=0, end=10, chunk_id=0)
+            location_in_text=LocationInText(chunk_id=0)
         )
-        
+
         mock_llm_instance = mock_llm_client.return_value
         mock_llm_instance.extract_claims_from_chunk.return_value = [claim]
-        
+
         extractor = HybridClaimExtractor()
-        result = extractor.extract_claims_from_text("Sample text")
-        
-        # Location should be updated with chunk's start position
-        assert result[0].location_in_text.start == 100
-        assert result[0].location_in_text.end == 110
+        result = extractor.extract_claims_from_text(full_text)
+
+        loc = result[0].location_in_text
+        assert loc.start == span_start
+        # Slicing the source with the span must reproduce the claim exactly.
+        assert full_text[loc.start:loc.end] == "The sky is blue."
+
+    @patch('hybrid_citation_scraper.claim_extractor.LLMClient')
+    @patch('hybrid_citation_scraper.claim_extractor.semantic_chunk_text')
+    def test_extract_claims_locates_span_across_whitespace(
+        self, mock_chunk, mock_llm_client
+    ):
+        """Claims whose whitespace was normalized by the LLM are still located."""
+        # Source has a newline the LLM collapsed to a single space.
+        full_text = "The results\nwere significant."
+        mock_chunk.return_value = [
+            {'chunk_id': 0, 'text': full_text,
+             'start_pos': 0, 'end_pos': len(full_text), 'token_count': 4}
+        ]
+
+        claim = ClaimObject(
+            claim_id="test",
+            text="The results were significant.",  # single space, no newline
+            claim_type="qualitative",
+            citation_found=False,
+            is_original=True,
+            location_in_text=LocationInText(chunk_id=0)
+        )
+
+        mock_llm_instance = mock_llm_client.return_value
+        mock_llm_instance.extract_claims_from_chunk.return_value = [claim]
+
+        extractor = HybridClaimExtractor()
+        result = extractor.extract_claims_from_text(full_text)
+
+        loc = result[0].location_in_text
+        assert full_text[loc.start:loc.end] == "The results\nwere significant."
+
+    @patch('hybrid_citation_scraper.claim_extractor.LLMClient')
+    @patch('hybrid_citation_scraper.claim_extractor.semantic_chunk_text')
+    def test_extract_claims_unlocatable_span_is_none(
+        self, mock_chunk, mock_llm_client
+    ):
+        """A claim the LLM paraphrased beyond matching yields None offsets."""
+        mock_chunk.return_value = [
+            {'chunk_id': 0, 'text': 'Some source text.',
+             'start_pos': 0, 'end_pos': 17, 'token_count': 3}
+        ]
+
+        claim = ClaimObject(
+            claim_id="test",
+            text="A completely different paraphrase.",
+            claim_type="qualitative",
+            citation_found=False,
+            is_original=True,
+            location_in_text=LocationInText(chunk_id=0)
+        )
+
+        mock_llm_instance = mock_llm_client.return_value
+        mock_llm_instance.extract_claims_from_chunk.return_value = [claim]
+
+        extractor = HybridClaimExtractor()
+        result = extractor.extract_claims_from_text("Some source text.")
+
+        loc = result[0].location_in_text
+        assert loc.start is None
+        assert loc.end is None
+        assert loc.chunk_id == 0
     
     @patch('hybrid_citation_scraper.claim_extractor.LLMClient')
     @patch('hybrid_citation_scraper.claim_extractor.semantic_chunk_text')

--- a/models.py
+++ b/models.py
@@ -16,9 +16,15 @@ class CitationDetails(BaseModel):
 
 
 class LocationInText(BaseModel):
-    """Location of claim in source text"""
-    start: int
-    end: int
+    """Character span of a claim within the full extracted document text.
+
+    ``start``/``end`` are absolute character offsets into the text passed to the
+    claim extractor (the full PDF text), suitable for highlighting the claim in
+    the source. They are ``None`` when the claim could not be located in the
+    source text (e.g. the LLM paraphrased it beyond a whitespace-tolerant match).
+    """
+    start: Optional[int] = None
+    end: Optional[int] = None
     chunk_id: Optional[int] = None
 
 


### PR DESCRIPTION
Previously every claim's location_in_text.start/end were identical (both 0 in single-chunk papers, both equal to the chunk's start_pos otherwise), so they pointed at the start of the containing chunk rather than the claim itself and were never usable for locating a claim in the source. The offsets were also never read by any downstream stage.

Make start/end real, exact character offsets into the full extracted document text so consumers can highlight the actual claim:

- llm_client.py: stop hardcoding start=0/end=0 (the LLM only sees a chunk). The extracted claim now records just its chunk_id; offsets are resolved later where the full document text is available.

- claim_extractor.py: add _locate_claim_span() and locate each claim directly in the full document text (not the chunk). This avoids the chunker's whitespace drift: semantic_chunk_text rebuilds chunks with ' '.join(sentences), collapsing original whitespace, so chunk start_pos no longer lines up with the source. Locating against the real text guarantees full_text[start:end] reproduces the claim. The locator tries an exact match, then a whitespace-tolerant regex (the LLM often normalizes newlines/spaces), using the chunk start_pos as a hint to disambiguate a sentence that appears more than once.

- models.py: LocationInText.start/end are now Optional[int] (default None). None honestly means "could not locate" (e.g. the LLM paraphrased the claim), distinct from a real offset of 0.

- tests: replace the stale start_pos-addition assertion with three tests covering exact-span location, whitespace-normalized location, and the unlocatable -> None case.